### PR TITLE
Remove base-10 from video-sponsors.js

### DIFF
--- a/components/kickoff/video-sponsors.js
+++ b/components/kickoff/video-sponsors.js
@@ -96,7 +96,6 @@ export default class VideoSponsors extends React.Component {
     const beepleSrc = 'https://f1.srnd.org/beeple';
     const beepleAvailable = [
       'moonvirus',
-      'base-10',
       'strt',
       'xannn',
       '24k',


### PR DESCRIPTION
Base-10 is not a looping VFX, and there is a hard cut when the video restarts. Removed the object `base-10` from the `beepleAvailable` array.